### PR TITLE
Fix timezone support on postgres. Fixes #35

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# dbt_stripe v0.6.2
+## 🐞 Bug Fixes 🐞
+- [#35](https://github.com/fivetran/dbt_stripe/issues/35): Fix issue with timezone conversion on postgres.
+
 # dbt_stripe v0.6.1
 ## 🐞 Bug Fixes 🐞
 - [#24](https://github.com/fivetran/dbt_stripe/issues/24): Updating docs to add `dbt_stripe` documentation in addition to `dbt_stripe_source` documentation.

--- a/dbt_project.yml
+++ b/dbt_project.yml
@@ -1,6 +1,6 @@
 config-version: 2
 name: 'stripe'
-version: '0.6.1'
+version: '0.6.2'
 require-dbt-version: [">=1.0.0", "<2.0.0"]
 models:
   stripe:

--- a/integration_tests/dbt_project.yml
+++ b/integration_tests/dbt_project.yml
@@ -1,7 +1,7 @@
 config-version: 2
 
 name: 'stripe_integration_tests'
-version: '0.6.1'
+version: '0.6.2'
 profile: 'integration_tests'
 
 vars:

--- a/macros/date_timezone.sql
+++ b/macros/date_timezone.sql
@@ -13,6 +13,22 @@ date(
 
 {%- endmacro %}
 
+{% macro postgres__date_timezone(column) -%}
+
+{% set converted_date %}
+
+{% if var('stripe_timezone', none) %}
+    {{ column }} at time zone '{{ var('stripe_timezone') }}'
+{% else %}
+    {{ column }}
+{% endif %}
+
+{% endset %}
+
+{{ dbt_utils.date_trunc('day',converted_date) }}
+
+{%- endmacro %}
+
 {% macro default__date_timezone(column) -%}
 
 {% set converted_date %}


### PR DESCRIPTION
Pull Request
**Are you a current Fivetran customer?** 
Yes. John Ferlito, Cofounder, Gladly Pty Ltd

**What change(s) does this PR introduce?** 
Fixes issues with time zone conversion for postgres

**Did you update the CHANGELOG?** 
- [x] Yes

**Does this PR introduce a breaking change?**
- [ ] Yes (please provide breaking change details below.)
- [x] No  (please provide an explanation as to how the change is non-breaking below.)

If someone on postgres has a timezone set then the package fails to work anyway.

**Did you update the dbt_project.yml files with the version upgrade (please leverage standard semantic versioning)? (In both your main project and integration_tests)** 
- [x] Yes

**Is this PR in response to a previously created Bug or Feature Request**
- [x] Yes, Issue/Feature #35 
- [ ] No 

**How did you test the PR changes?** 
- [ ] CircleCi <!--- CircleCi testing is only applicable to Fivetran employees. --> 
- [x] Local (please provide additional testing details below)
Used the package on my local model and I can now use the stripe module with atimezone set

**Select which warehouse(s) were used to test the PR**
- [ ] BigQuery
- [ ] Redshift
- [ ] Snowflake
- [x] Postgres
- [ ] Databricks
- [ ] Other (provide details below)

**Provide an emoji that best describes your current mood**
:penguin: 